### PR TITLE
[MERGE AFTER #35] Feature/#31 disable sync scroll

### DIFF
--- a/js/admin/stopAutoScroll.js
+++ b/js/admin/stopAutoScroll.js
@@ -1,0 +1,39 @@
+(function() {
+  const findPanes = function(parent) {
+    // CMS listens for the scroll event in its vertical panels to keep them in sync:
+    // https://github.com/netlify/netlify-cms/tree/master/src/components/ScrollSync
+    const panes = parent && parent.querySelectorAll('.Pane.vertical');
+    if(panes) {
+      panes.forEach(follow);
+    }
+  };
+
+  const findIframe = function(parent) {
+    // It also listens from inside the preview iframe.
+    const iframe = parent && parent.querySelector('.cms__PreviewPane__frame');
+    if(iframe) {
+      follow(iframe.contentWindow);
+    }
+  };
+
+  const follow = function(pane) {
+    pane.addEventListener('scroll', function(e) {
+      // We only need to prevent this event from reaching CMS's own event listeners in its React components.
+      e.stopPropagation();
+    }, true);
+  };
+
+  // Because it's a React app, its nodes are constantly re-rendered, so we need to keep reapplying our listener.
+  const observer = new MutationObserver(function(mutations) {
+    mutations.forEach(function(m) {
+      findPanes(m.target);
+      findIframe(m.target);
+    });
+  });
+
+  observer.observe(document.body, { childList: true, subtree: true });
+
+  // Disable scroll sync if we're loading directly into an editing page.
+  findPanes(document.body);
+  findIframe(document.body);
+})();

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -9,5 +9,5 @@
   <body>
     <script src="https://unpkg.com/netlify-cms@0.4.6/dist/cms.js"></script>
     <script src="../js/app.min.js"></script>
-    <!--<script src="main.min.js"></script>-->
+    <script src="main.min.js"></script>
   </body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,8 +22,8 @@ module.exports = [
   Object.assign({
     // Here the application starts executing and webpack starts bundling
     entry: {
-      js: glob.sync("./js/site/**/*.js")
-      //admin: glob.sync("./js/admin/**/*.js")
+      js: glob.sync("./js/site/**/*.js"),
+      admin: glob.sync("./js/admin/**/*.js")
     },
 
     // options related to how webpack emits results


### PR DESCRIPTION
Closes #31 - Disable synchronized scrolling in preview panes

Branched from #29 because it needs the code updates from the CMS update PR...