### PR TITLE
Feature/#30 Use JS functionality in previews

### DIFF
--- a/js/site/site.js
+++ b/js/site/site.js
@@ -1,55 +1,6 @@
 import $ from 'jquery';
-import 'slick-carousel';
 
 $(function() {
-
-  var breakMobile = 730; // viewport px breakpoint
-
-  const fixedHeader = function() {
-    var viewportWidth = $( window ).width(),
-        fixedClass = 'navigation--fixed-top',
-        $navElement = $(".navigation");
-
-    if ($(window).scrollTop() > '1' && viewportWidth >= breakMobile) {
-      $navElement.addClass(fixedClass);
-    } else {
-      $navElement.removeClass(fixedClass);
-    }
-  };
-
-  const showLogo = function() {
-    var viewportWidth = $( window ).width(),
-        logovisibleClass = 'visible-logo',
-        $logoElement = $(".navigation-logo");
-
-    if ($(window).scrollTop() > '150' && viewportWidth >= breakMobile) {
-      $logoElement.addClass(logovisibleClass);
-    } else {
-     $logoElement.removeClass(logovisibleClass);
-    }
-  };
-
-  // Toggle mobile navigation
-  $(".navigation__mobile-menu__toggle").click(function() {
-    $(this).parent().toggleClass('is-open');
-  });
-
-  // Force close mobile navigation when clicking anywhere (except the toggle button itself)
-  $( document ).on('mousedown touchstart', function(event) {
-    if (!$(event.target).closest(".navigation").length) {
-      $(".navigation.is-open").removeClass('is-open');
-    }
-  });
-
-  $('.slider__wrapper').slick({
-    autoplay: true,
-    autoplaySpeed: 5000,
-    fade: true,
-    speed: 1200,
-    prevArrow: '<a href="#" class="slick-prev"><span class="slick-arrow-mz slick-arrow-mz--left"><svg><use xlink:href="#slider_arrow_left"></use></svg></span></a>',
-    nextArrow: '<a href="#" class="slick-next"><span class="slick-arrow-mz slick-arrow-mz--right"><svg><use xlink:href="#slider_arrow_right"></use></svg></span></a>'
-  });
-
   //- function for g maps
   /*
   function gmaps() {
@@ -62,8 +13,6 @@ $(function() {
     });
   };
   */
-  $(window).on('resize scroll', fixedHeader);
-    $(window).on('resize scroll', showLogo);
   filtro();
   //gmaps();
 });

--- a/jsx/Besugo.jsx
+++ b/jsx/Besugo.jsx
@@ -90,3 +90,13 @@ export default class BesugoComponent extends React.Component {
 // BesugoComponent.propTypes = {
 //   xplaceholder: PropTypes.instanceOf(Element)
 // };
+
+// When in CMS preview, we're running in the parent window context, while for most cases we will need
+// the preview iframe's environment.
+export function frameView() {
+  if(typeof(CMS) !== 'undefined') {
+    const $ = require('jquery');
+    return $('iframe.cms__PreviewPane__frame')[0].contentWindow;
+  }
+  return window;
+}

--- a/jsx/partials/SlideShow.jsx
+++ b/jsx/partials/SlideShow.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import BesugoComponent from 'Besugo';
+import $ from 'jquery';
+import 'slick-carousel';
+
+const config = {
+  autoplay: true,
+  autoplaySpeed: 5000,
+  fade: true,
+  speed: 1200,
+  prevArrow: '<a href="#" class="slick-prev"><span class="slick-arrow-mz slick-arrow-mz--left"><svg><use xlink:href="#slider_arrow_left"></use></svg></span></a>',
+  nextArrow: '<a href="#" class="slick-next"><span class="slick-arrow-mz slick-arrow-mz--right"><svg><use xlink:href="#slider_arrow_right"></use></svg></span></a>'
+};
+
+class SlideShow extends BesugoComponent {
+  static get config() {
+    return {
+      tag: 'SlideShow'
+    };
+  }
+
+  getData() {
+    const data = Object.assign({
+      slides: []
+    }, this.props);
+
+    if(this.props.xplaceholder) {
+      const slides = this.props.xplaceholder.querySelectorAll('SlideShowSlide');
+      slides.forEach(function(slide) {
+        data.slides.push({
+          title: slide.getAttribute('title'),
+          image: slide.getAttribute('image'),
+          link: {
+            label: slide.getAttribute('link-label'),
+            url: slide.getAttribute('link-url')
+          }
+        });
+      });
+    }
+
+    return data;
+  }
+
+  componentDidMount() {
+    // It would be SO MUCH BETTER if we could use react-slick (https://github.com/akiran/react-slick),
+    // but that has trouble in the CMS preview page, likely because we're running in the parent frame but
+    // building in an inner frame (fails to find the DOM node: "unable to find node on an unmounted component").
+    // And simply injecting the main.min.js file won't work because the component keeps rebuilding, so we have
+    // to constantly reinitialize it. Hence this "hybrid" approach.
+    // PS. Couldn't find other react-based carousel modules that supported a fade animation like slick does.
+    $(this.wrapper).slick(config);
+  }
+
+  buildSlides(data) {
+    let i = 0;
+    return data.slides && data.slides.map(function(slide) {
+      return (
+        <div className="teaser__wrapper" key={ "slide-" + (i++) }>
+          <div className="teaser__text">
+            <p className="teaser__text-content">{ slide.title }</p>
+            <p className="teaser__text-content">
+              <a href={ slide.link.url } className="link__button-white-secondary">{ slide.link.label }</a>
+            </p>
+          </div>
+          <img className="teaser__element" src={ slide.image }/>
+        </div>
+      )
+    })
+  }
+
+  render() {
+    const data = this.getData();
+
+    return (
+      <div
+        className="slider__wrapper"
+        ref={ (wrapper) => { this.wrapper = wrapper; } }>
+
+        { this.buildSlides(data) }
+      </div>
+    );
+  }
+};
+
+SlideShow.initialize();
+export default SlideShow;

--- a/layouts/partials/styleguide.html
+++ b/layouts/partials/styleguide.html
@@ -88,42 +88,26 @@
 
   <section class="styleguide__section-component">
 
-    <div class="slider__wrapper">
-
-
-      <div class="teaser__wrapper">
-
-        <div class="teaser__text">
-          <p class="teaser__text-content">First Slide</p>
-          <p class="teaser__text-content"><a href="#" class="link__button-white-secondary">Link</a></p>
-        </div>
-
-        <img class="teaser__element" src="/images/example.jpg">
-
-      </div> <!-- teaser__wrapper -->
-
-      <div class="teaser__wrapper">
-
-        <div class="teaser__text">
-          <p class="teaser__text-content">Second Slide </p>
-          <p class="teaser__text-content"><a href="#" class="link__button-white-secondary">Link</a></p>
-        </div>
-
-        <img class="teaser__element" src="/images/example.jpg">
-
-      </div> <!-- teaser__wrapper -->
-
-      <div class="teaser__wrapper">
-
-        <div class="teaser__text">
-          <p class="teaser__text-content">Third Slide</p>
-          <p class="teaser__text-content"><a href="#" class="link__button-white-secondary">Link</a></p>
-        </div>
-
-        <img class="teaser__element" src="/images/example.jpg">
-
-      </div> <!-- teaser__wrapper -->
-    </div>
+    <SlideShow>
+      <SlideShowSlide
+        title="First Slide"
+        image="/images/example.jpg"
+        link-label="Link"
+        link-url="#"
+      ></SlideShowSlide>
+      <SlideShowSlide
+        title="Second Slide"
+        image="/images/example.jpg"
+        link-label="Link"
+        link-url="#"
+      ></SlideShowSlide>
+      <SlideShowSlide
+        title="Third Slide"
+        image="/images/example.jpg"
+        link-label="Link"
+        link-url="#"
+      ></SlideShowSlide>
+    </SlideShow>
 
   </section>
 

--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -7,6 +7,7 @@
   text-transform: uppercase;
   position: relative;
   background-color: palette(grey);
+  transition: background ease 0.3s;
 
   @include mq($until: break-medium) {
     position: fixed;
@@ -25,10 +26,11 @@
     max-height: ritmo(16);
     padding-bottom: ritmo(15);
     text-align: center;
-  }
 
-  &.navigation--fixed-top {
-    transition: background ease 0.3s;
+    &.navigation--fixed-top {
+      // Uncomment and customize as necessary
+      background-color: palette(black);
+    }
   }
 }
 
@@ -203,6 +205,10 @@
     opacity: 0;
     top: 20px;
     left: 10px;
+
+    &.visible-logo {
+      opacity: 1;
+    }
   }
 
   .navigation-logo__svg {
@@ -264,8 +270,4 @@
     width: 80px;
     line-height: 14px;
   }
-}
-
-.visible-logo {
-  opacity: 1;
 }

--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -29,7 +29,7 @@
 
     &.navigation--fixed-top {
       // Uncomment and customize as necessary
-      background-color: palette(black);
+      //background-color: palette(black);
     }
   }
 }


### PR DESCRIPTION
Closes #30 - Use JS funcionality in previews

- [x] Moved functions related to the header from ```main.min.js``` (jQuery/JS) into ```TopHeader.jsx``` (react-friendly JS), such as the logo being visible after scrolling, and the header background change (not visible in Besugo's styleguide out-of-the-box).
- [x] Reorganized the CSS a bit, just because.

## Notes
The ```main.min.js``` file still exists and will still be needed on every project most likely.

This means that porting the specific functions in this PR in other projects should "just work", but every project will have to be done on a case-by-case basis, meaning that each specific functionality (that should exist in the previews of course) will have to be ported individually.

For instance, in PWiT, we might leave the filters functionality in ```main.min.js```, since it won't be needed in any preview page. But we will definitely need to port a lot of functions in UHUB, such as the extras and related stuff.