### PR TITLE
#54 Remove unused files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,3 @@ Thumbs.db
 !.gitkeep
 static/css/app.css
 static/css/admin.css
-static/js/main.min.js
-static/js/app.min.js
-static/admin/main.min.js


### PR DESCRIPTION
If updating an existing Besugo instance with the new code, some leftover `js` may remain in the static folder, overwriting the actual scripts built by webpack when building. The files listed in this commit should be deleted if they exist locally.